### PR TITLE
Change badge to use iconnect CI account on Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/RNCryptor/regex.svg?branch=master)](https://travis-ci.org/iconnect/regex)
+[![Build Status](https://travis-ci.org/iconnect/regex.svg?branch=master)](https://travis-ci.org/iconnect/regex)
 [![Build status](https://ci.appveyor.com/api/projects/status/vj3d35qptms3q23w?svg=true)](https://ci.appveyor.com/project/iconnect/regex)
 [![Coverage Status](https://coveralls.io/repos/github/RNCryptor/regex/badge.svg?branch=master)](https://coveralls.io/github/iconnect/regex?branch=master)
 


### PR DESCRIPTION
@cdornan a quick one (hope you don't mind if I help myself and merge it).

I have updated the README badge to use the "official" iconnect Travis account, and make Hallybot admin of this repo (it was necessary in order to enable Travis access, let's review if you think this is not good. Maybe it's possible to revoke access once you enabled the repo the first time).