### PR TITLE
Better code coverage (fixes #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,16 @@ Icon
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
 
+
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
 Network Trash Folder
 Temporary Items
 .apdisk
+
+
+# Coveralls
+
+/shc
+/shc-*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Hackage](https://img.shields.io/hackage/v/regex.svg)](https://hackage.haskell.org/package/regex)
 [![BSD3 License](http://img.shields.io/badge/license-BSD3-brightgreen.svg)](https://tldrlegal.com/license/bsd-3-clause-license-%28revised%29)
-[![Un*x build](https://img.shields.io/travis/iconnect/regex.svg?label=Linux%2FmacOS)](https://hackage.haskell.org/package/regex)
+[![Un*x build](https://img.shields.io/travis/iconnect/regex.svg?label=Linux%2FmacOS)](https://travis-ci.org/iconnect/regex)
 [![Windows build](https://img.shields.io/appveyor/ci/engineerirngirisconnectcouk/regex.svg?label=Windows)](https://ci.appveyor.com/project/engineerirngirisconnectcouk/regex/branch/master)
 [![Coverage](https://img.shields.io/coveralls/iconnect/regex.svg)](https://coveralls.io/github/iconnect/regex?branch=master)
 

--- a/Text/RE/Internal/PreludeMacros.hs
+++ b/Text/RE/Internal/PreludeMacros.hs
@@ -8,6 +8,7 @@ module Text.RE.Internal.PreludeMacros
   , MacroDescriptor(..)
   , RegexSource(..)
   , PreludeMacro(..)
+  , presentPreludeMacro
   , preludeMacros
   , preludeMacroTable
   , preludeMacroSummary
@@ -142,7 +143,7 @@ natural_macro rty env pm = Just $ run_tests rty parseInteger samples env pm
     { _md_source          = "[0-9]+"
     , _md_samples         = map fst samples
     , _md_counter_samples = counter_samples
-    , _md_test_results    = test_stub pm
+    , _md_test_results    = []
     , _md_parser          = Just "parseInteger"
     , _md_description     = "a string of one or more decimal digits"
     }
@@ -170,7 +171,7 @@ natural_hex_macro rty env pm = Just $ run_tests rty parseHex samples env pm
     { _md_source          = "[0-9a-fA-F]+"
     , _md_samples         = map fst samples
     , _md_counter_samples = counter_samples
-    , _md_test_results    = test_stub pm
+    , _md_test_results    = []
     , _md_parser          = Just "parseHex"
     , _md_description     = "a string of one or more hexadecimal digits"
     }
@@ -198,7 +199,7 @@ integer_macro rty env pm = Just $ run_tests rty parseInteger samples env pm
     { _md_source          = "-?[0-9]+"
     , _md_samples         = map fst samples
     , _md_counter_samples = counter_samples
-    , _md_test_results    = test_stub pm
+    , _md_test_results    = []
     , _md_parser          = Just "parseInteger"
     , _md_description     = "a decimal integer"
     }
@@ -226,7 +227,7 @@ decimal_macro rty env pm = Just $ run_tests rty parseDouble samples env pm
     { _md_source          = "-?[0-9]+(?:\\.[0-9]+)?"
     , _md_samples         = map fst samples
     , _md_counter_samples = counter_samples
-    , _md_test_results    = test_stub pm
+    , _md_test_results    = []
     , _md_parser          = Just "parseInteger"
     , _md_description     = "a decimal integer"
     }
@@ -267,7 +268,7 @@ string_macro rty@TDFA env pm =
       { _md_source          = "\"(?:[^\"\\]+|\\\\[\\\"])*\""
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseString"
       , _md_description     = "a double-quote string, with simple \\ escapes for \\s and \"s"
       }
@@ -298,7 +299,7 @@ string_simple_macro rty env pm =
       { _md_source          = "\"[^\"[:cntrl:]]*\""
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseSimpleString"
       , _md_description     = "a decimal integer"
       }
@@ -331,7 +332,7 @@ id_macro rty env pm =
       { _md_source          = "_*[a-zA-Z][a-zA-Z0-9_]*"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Nothing
       , _md_description     = "a standard C-style alphanumeric identifier (with _s)"
       }
@@ -369,7 +370,7 @@ id'_macro rty env pm =
       { _md_source          = "_*[a-zA-Z][a-zA-Z0-9_']*"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Nothing
       , _md_description     = "a standard Haskell-style alphanumeric identifier (with '_'s and '''s)"
       }
@@ -410,7 +411,7 @@ date_macro rty env pm =
       { _md_source          = "[0-9]{4}-[0-9]{2}-[0-9]{2}"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseDate"
       , _md_description     = "a YYYY-MM-DD format date"
       }
@@ -442,7 +443,7 @@ date_slashes_macro rty env pm =
       { _md_source          = "[0-9]{4}/[0-9]{2}/[0-9]{2}"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseSlashesDate"
       , _md_description     = "a YYYY/MM/DD format date"
       }
@@ -474,7 +475,7 @@ time_macro rty env pm =
       { _md_source          = "[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseTimeOfDay"
       , _md_description     = "a HH:MM:SS[.Q+]"
       }
@@ -507,7 +508,7 @@ timezone_macro rty env pm =
       { _md_source          = "(?:Z|[+-][0-9]{2}:?[0-9]{2})"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseTimeZone"
       , _md_description     = "an IOS-8601 TZ specification"
       }
@@ -538,7 +539,7 @@ datetime_macro rty env pm = Just $ run_tests rty parseDateTime samples env pm
     { _md_source          = "@{%date}[ T]@{%time}(?:@{%timezone}| UTC)?"
     , _md_samples         = map fst samples
     , _md_counter_samples = counter_samples
-    , _md_test_results    = test_stub pm
+    , _md_test_results    = []
     , _md_parser          = Just "parseDateTime"
     , _md_description     = "ISO-8601 format date and time + simple variants"
     }
@@ -572,7 +573,7 @@ datetime_8601_macro rty env pm =
       { _md_source          = "@{%date}T@{%time}@{%timezone}"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseDateTime8601"
       , _md_description     = "YYYY-MM-DDTHH:MM:SS[.Q*](Z|[+-]HHMM) format date and time"
       }
@@ -599,7 +600,7 @@ datetime_clf_macro rty env pm =
       { _md_source          = re
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseDateTimeCLF"
       , _md_description     = "Common Log Format date+time: %d/%b/%Y:%H:%M:%S %z"
       }
@@ -638,7 +639,7 @@ shortmonth_macro rty env pm =
                                 intercalate "|" $ elems shortMonthArray
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseShortMonth"
       , _md_description     = "three letter month name: Jan-Dec"
       }
@@ -671,7 +672,7 @@ address_ipv4_macros rty env pm =
       { _md_source          = "[0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseSeverity"
       , _md_description     = "an a.b.c.d IPv4 address"
       }
@@ -707,7 +708,7 @@ syslog_severity_macro rty env pm =
       { _md_source          = re
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Just "parseSeverity"
       , _md_description     = "syslog severity keyword (debug-emerg)"
       }
@@ -764,7 +765,7 @@ email_simple_macro rty env pm =
       { _md_source          = "[a-zA-Z0-9%_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9.-]+"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Nothing
       , _md_description     = "an email address"
       }
@@ -793,7 +794,7 @@ url_macro rty env pm =
       { _md_source          = "([hH][tT][tT][pP][sS]?|[fF][tT][pP])://[^[:space:]/$.?#].[^[:space:]]*"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = test_stub pm
+      , _md_test_results    = []
       , _md_parser          = Nothing
       , _md_description     = "a URL"
       }
@@ -828,10 +829,6 @@ url_macro rty env pm =
         , "http://##"
         , "http://##/"
         ]
-
-test_stub :: PreludeMacro -> [TestResult]
-test_stub pm =
-  error $ "test_stub: tests missing: " ++ presentPreludeMacro pm
 
 run_tests :: (Eq a,Show a)
           => RegexType

--- a/Text/RE/Internal/QQ.hs
+++ b/Text/RE/Internal/QQ.hs
@@ -1,21 +1,26 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+
 module Text.RE.Internal.QQ where
 
+import           Control.Exception
+import           Data.Typeable
 import           Language.Haskell.TH.Quote
 
 
-qq0 :: String -> QuasiQuoter
-qq0 nm =
-  QuasiQuoter
-    { quoteExp  = const $ error $ oops "an expression"
-    , quotePat  = const $ error $ oops "a pattern"
-    , quoteType = const $ error $ oops "a type"
-    , quoteDec  = const $ error $ oops "a declaration"
+data QQFailure =
+  QQFailure
+    { _qqf_context   :: String
+    , _qqf_component :: String
     }
-  where
-    oops sc = unwords
-      [ "`"
-      , nm
-      , "` QuasiQuoter has been used in"
-      , sc
-      , "context but it should be used in an expresion context."
-      ]
+  deriving (Show,Typeable)
+
+instance Exception QQFailure where
+
+qq0 :: String -> QuasiQuoter
+qq0 ctx =
+  QuasiQuoter
+    { quoteExp  = const $ throw $ QQFailure ctx "expression"
+    , quotePat  = const $ throw $ QQFailure ctx "pattern"
+    , quoteType = const $ throw $ QQFailure ctx "type"
+    , quoteDec  = const $ throw $ QQFailure ctx "declaration"
+    }

--- a/Text/RE/Options.lhs
+++ b/Text/RE/Options.lhs
@@ -17,10 +17,10 @@ import           Language.Haskell.TH.Syntax
 \begin{code}
 data Options_ r c e =
   Options
-    { _options_mode :: Mode
-    , _options_macs :: Macros r
-    , _options_comp :: c
-    , _options_exec :: e
+    { _options_mode :: !Mode
+    , _options_macs :: !(Macros r)
+    , _options_comp :: !c
+    , _options_exec :: !e
     }
   deriving (Show)
 \end{code}

--- a/Text/RE/PCRE/RE.hs
+++ b/Text/RE/PCRE/RE.hs
@@ -79,10 +79,10 @@ regexType = PCRE
 
 data RE =
   RE
-    { _re_options :: Options
-    , _re_source  :: String
-    , _re_cnames  :: CaptureNames
-    , _re_regex   :: Regex
+    { _re_options :: !Options
+    , _re_source  :: !String
+    , _re_cnames  :: !CaptureNames
+    , _re_regex   :: !Regex
     }
 
 reOptions :: RE -> Options
@@ -177,8 +177,6 @@ compileRegex_ os re_s = uncurry mk <$> compileRegex' os re_s
         , _re_cnames  = cnms
         , _re_regex   = rex
         }
-
-    Options{..} = os
 
 re' :: Maybe SimpleRegexOptions -> QuasiQuoter
 re' mb = case mb of

--- a/Text/RE/TDFA/RE.hs
+++ b/Text/RE/TDFA/RE.hs
@@ -78,10 +78,10 @@ regexType = TDFA
 
 data RE =
   RE
-    { _re_options :: Options
-    , _re_source  :: String
-    , _re_cnames  :: CaptureNames
-    , _re_regex   :: Regex
+    { _re_options :: !Options
+    , _re_source  :: !String
+    , _re_cnames  :: !CaptureNames
+    , _re_regex   :: !Regex
     }
 
 reOptions :: RE -> Options
@@ -173,8 +173,6 @@ compileRegex_ os re_s = uncurry mk <$> compileRegex' os re_s
         , _re_cnames  = cnms
         , _re_regex   = rx
         }
-
-    Options{..} = os
 
 re' :: Maybe SimpleRegexOptions -> QuasiQuoter
 re' mb = case mb of

--- a/Text/RE/TestBench.lhs
+++ b/Text/RE/TestBench.lhs
@@ -23,7 +23,7 @@ module Text.RE.TestBench
   , formatMacroSources
   , formatMacroSource
   , testMacroDescriptors
-  , regexSource
+-- , regexSource
   ) where
 
 import           Data.Array
@@ -49,7 +49,7 @@ Types
 data RegexType
   = TDFA    -- the TDFA back end
   | PCRE    -- the PCRE back end
-  deriving (Eq,Ord,Show)
+  deriving (Bounded,Enum,Eq,Ord,Show)
 
 -- | do we need the captures in the RE or whould they be stripped out
 -- where possible
@@ -66,12 +66,12 @@ type MacroEnv = HML.HashMap MacroID MacroDescriptor
 -- description
 data MacroDescriptor =
   MacroDescriptor
-    { _md_source          :: RegexSource      -- ^ the RE
-    , _md_samples         :: [String]         -- ^ some sample matches
-    , _md_counter_samples :: [String]         -- ^ some sample non-matches
-    , _md_test_results    :: [TestResult]     -- ^ validation test results
-    , _md_parser          :: Maybe FunctionID -- ^ WA, the parser function
-    , _md_description     :: String           -- ^ summary comment
+    { _md_source          :: !RegexSource         -- ^ the RE
+    , _md_samples         :: ![String]            -- ^ some sample matches
+    , _md_counter_samples :: ![String]            -- ^ some sample non-matches
+    , _md_test_results    :: ![TestResult]        -- ^ validation test results
+    , _md_parser          :: !(Maybe FunctionID)  -- ^ WA, the parser function
+    , _md_description     :: !String              -- ^ summary comment
     }
   deriving (Show)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Loading up the Tutorial into ghci
 ```bash
 cabal unpack regex
 cd regex-*
-cabal configure --enable-tests
+cabal configure
 cabal repl examples/re-tutorial
 ```
 

--- a/examples/re-nginx-log-processor.lhs
+++ b/examples/re-nginx-log-processor.lhs
@@ -298,7 +298,7 @@ user_macro env mid =
       { _md_source          = "(?:-|[^[:space:]]+)"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = def_test_results
+      , _md_test_results    = []
       , _md_parser          = Just "parse_user"
       , _md_description     = "a user ident (per RFC1413)"
       }
@@ -321,7 +321,7 @@ pid_tid_macro env mid =
       { _md_source          = "(?:@{%natural})#(?:@{%natural}):"
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = def_test_results
+      , _md_test_results    = []
       , _md_parser          = Just "parse_pid_tid"
       , _md_description     = "<PID>#<TID>:"
       }
@@ -346,7 +346,7 @@ access_macro env mid =
       { _md_source          = access_re
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = def_test_results
+      , _md_test_results    = []
       , _md_parser          = Just "parse_a"
       , _md_description     = "an Nginx access log file line"
       }
@@ -379,7 +379,7 @@ access_deg_macro env mid =
       { _md_source          = " -  \\[\\] \"\"   \"\" \"\" \"\""
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = def_test_results
+      , _md_test_results    = []
       , _md_parser          = Nothing
       , _md_description     = "a degenerate Nginx access log file line"
       }
@@ -401,7 +401,7 @@ error_macro env mid =
       { _md_source          = error_re
       , _md_samples         = map fst samples
       , _md_counter_samples = counter_samples
-      , _md_test_results    = def_test_results
+      , _md_test_results    = []
       , _md_parser          = Just "parse_e"
       , _md_description     = "an Nginx error log file line"
       }
@@ -430,9 +430,6 @@ error_macro env mid =
         [ ""
         , "foo"
         ]
-
-def_test_results :: [TestResult]
-def_test_results = error "def_test_results"
 \end{code}
 
 \begin{code}

--- a/regex.cabal
+++ b/regex.cabal
@@ -23,11 +23,11 @@ Cabal-version:          >= 1.16
 
 Source-repository head
     type:               git
-    location:           git://github.com/iconnect/regex.git
+    location:           https://github.com/iconnect/regex.git
 
 Source-Repository this
     Type:              git
-    Location:          git://github.com/iconnect/regex.git
+    Location:          https://github.com/iconnect/regex.git
     Tag:               0.0.0.1
 
 Library
@@ -37,6 +37,8 @@ Library
       Text.RE.CaptureID
       Text.RE.Edit
       Text.RE.Internal.NamedCaptures
+      Text.RE.Internal.PreludeMacros
+      Text.RE.Internal.QQ
       Text.RE.IsRegex
       Text.RE.LineNo
       Text.RE.Options
@@ -63,8 +65,6 @@ Library
 
     Other-modules:
       Text.RE.Internal.AddCaptureNames
-      Text.RE.Internal.PreludeMacros
-      Text.RE.Internal.QQ
 
     Build-depends:
       array                   >= 0.4            ,
@@ -115,6 +115,29 @@ Executable re-gen-modules
       text                    >= 1.2.1.3
 
 
+Test-Suite re-gen-modules-test
+    type:               exitcode-stdio-1.0
+    Hs-Source-Dirs:     examples
+
+    Main-is:            re-gen-modules.lhs
+
+    Default-Language:   Haskell2010
+    GHC-Options:
+        -Wall
+        -fwarn-tabs
+
+    Build-depends:
+      regex                                     ,
+      array                   >= 0.4            ,
+      bytestring              >= 0.10.2.0       ,
+      base                    >= 4       && < 5 ,
+      directory               >= 1.2.1.0        ,
+      regex-base              >= 0.93.2         ,
+      regex-tdfa              >= 1.2.0          ,
+      shelly                  >= 1.6.1.2        ,
+      text                    >= 1.2.1.3
+
+
 Executable re-include
     Hs-Source-Dirs:     examples
 
@@ -156,29 +179,6 @@ Test-Suite re-include-test
       bytestring              >= 0.10.2.0       ,
       base                    >= 4              ,
       directory               >= 1.2.1.0        ,
-      shelly                  >= 1.6.1.2        ,
-      text                    >= 1.2.1.3
-
-
-Test-Suite re-gen-modules-test
-    type:               exitcode-stdio-1.0
-    Hs-Source-Dirs:     examples
-
-    Main-is:            re-gen-modules.lhs
-
-    Default-Language:   Haskell2010
-    GHC-Options:
-        -Wall
-        -fwarn-tabs
-
-    Build-depends:
-      regex                                     ,
-      array                   >= 0.4            ,
-      bytestring              >= 0.10.2.0       ,
-      base                    >= 4       && < 5 ,
-      directory               >= 1.2.1.0        ,
-      regex-base              >= 0.93.2         ,
-      regex-tdfa              >= 1.2.0          ,
       shelly                  >= 1.6.1.2        ,
       text                    >= 1.2.1.3
 
@@ -306,10 +306,49 @@ Test-Suite re-tests
       regex-pcre-builtin      >= 0.94.4.8.8.35  ,
       tasty                   >= 0.10.1.2       ,
       tasty-hunit             >= 0.9.2          ,
+      template-haskell        >= 2.7            ,
       text                    >= 1.2.1.3
 
 
-Test-Suite re-tutorial
+Executable re-tutorial
+    Hs-Source-Dirs:     examples .
+
+    Main-is:            re-tutorial.lhs
+
+    Other-modules:
+      TestKit
+
+    Default-Language:   Haskell2010
+    Default-Extensions: QuasiQuotes
+    GHC-Options:
+        -Wall
+        -fwarn-tabs
+
+    Build-depends:
+      regex                                     ,
+      array                   >= 0.4            ,
+      bytestring              >= 0.10.2.0       ,
+      base                    >= 4       && < 5 ,
+      containers              >= 0.4            ,
+      directory               >= 1.2.1.0        ,
+      hashable                >= 1.2.3.3        ,
+      heredoc                 >= 0.2.0.0        ,
+      regex-base              >= 0.93.2         ,
+      regex-tdfa              >= 1.2.1          ,
+      regex-tdfa-text         >= 1.0.0.3        ,
+      regex-pcre-builtin      >= 0.94.4.8.8.35  ,
+      shelly                  >= 1.6.1.2        ,
+      smallcheck              >= 1.1.1          ,
+      tasty                   >= 0.10.1.2       ,
+      tasty-hunit             >= 0.9.2          ,
+      tasty-smallcheck        >= 0.8.0.1        ,
+      template-haskell        >= 2.7            ,
+      transformers            >= 0.2.2          ,
+      text                    >= 1.2.1.3        ,
+      time                    >= 1.5.0.1        ,
+      unordered-containers    >= 0.2.5.1
+
+Test-Suite re-tutorial-test
     type:               exitcode-stdio-1.0
     Hs-Source-Dirs:     examples .
 

--- a/save/travis.yml
+++ b/save/travis.yml
@@ -37,10 +37,12 @@ matrix:
   # https://github.com/hvr/multi-ghc-travis
 
 
-  # For the Stack builds we can pass in arbitrary Stack arguments via the ARGS
+  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
 
-  # Linux/stack
+  # - env: BUILD=stack ARGS=""
+  #   compiler: ": #stack default"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
     compiler: ": #stack 7.10.3"
@@ -54,7 +56,21 @@ matrix:
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  # Linux/cabal
+
+  # Nightly builds are allowed to fail
+  # - env: BUILD=stack ARGS="--resolver nightly"
+  #   compiler: ": #stack nightly"
+  #   addons: {apt: {packages: [libgmp-dev]}}
+
+  # Build on macOS in addition to Linux
+  # - env: BUILD=stack ARGS=""
+  #   compiler: ": #stack default osx"
+  #   os: osx
+
+
+  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.6.3"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
@@ -66,8 +82,17 @@ matrix:
     compiler: ": #GHC 8.0.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  # - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC HEAD"
+  #   addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  # macOS (stack)
+
+  # Travis includes an macOS which is incompatible with GHC 7.8.4
+  #- env: BUILD=stack ARGS="--resolver lts-2"
+  #  compiler: ": #stack 7.8.4 osx"
+  #  os: osx
 
   - env: BUILD=stack STACK_YAML=stack-7.10.yaml
     compiler: ": #stack 7.10.3 osx"
@@ -76,6 +101,11 @@ matrix:
   - env: BUILD=stack STACK_YAML=stack-8.0.yaml
     compiler: ": #stack 8.0.1 osx"
     os: osx
+
+  # - env: BUILD=stack ARGS="--resolver nightly"
+  #   compiler: ": #stack nightly osx"
+  #   os: osx
+
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7


### PR DESCRIPTION
Fixes #17. This should give us ~94% code coverage.

  * HPC coverage for all 6 test suites are reported to coveralls;

  * .travis.yml has been saved in `save` and rationalised with
    only the builds we need in it;

  * stack/GHC-7.10.3 seems to be the only setup that generates
    sensible coverage data so we only report coverage data for this
    build to coveralls and run this combination first;

  * now using https for repo urls in cabal file;

  * the readme.md trvis badge should link to the regex travis
    project.