### PR TITLE
Sort out repl (fixes #27)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,11 +61,21 @@ stack install regex
 Loading up the Tutorial into ghci
 ---------------------------------
 
+First unpack the source distribution.
 ```bash
 cabal unpack regex
 cd regex-*
+```
+
+Loading the tutorial into ghci with cabal:
+```
 cabal configure
-cabal repl examples/re-tutorial
+cabal repl re-tutorial
+```
+
+Loading the tutorial into ghci with stack:
+```
+stack --stack-yaml stack-8.0.yaml exec ghci -- -ghci-script lib/ghci examples/re-tutorial.lhs
 ```
 
 

--- a/lib/ghci
+++ b/lib/ghci
@@ -1,0 +1,6 @@
+:set -Wall
+
+:seti -XOverloadedStrings
+:seti -XQuasiQuotes
+
+:set -iexamples


### PR DESCRIPTION
Fixes #27:

  * removed stack.yaml and added to gitignore (so everyone can
    link to the apropriate syack-*.yaml);

  * lib/ghci added (needed for the 'stack repl' instructions);

  * instructions for cabal fixed and instructions for stack
    loading of the tutorial into ghci added.