### PR TITLE
switch to 8.0.2

### DIFF
--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,7 +1,8 @@
-resolver: lts-7.18
+resolver: lts-8.4
 install-ghc: true
 flags: {}
 packages:
 - '.'
 system-ghc: false
-extra-deps: []
+extra-deps:
+  - shelly-1.6.8.3


### PR DESCRIPTION
Shelly needs to be in extra-deps for lts-8.4 &mdash; we probably want that to be fixed before merging.