### PR TITLE
Declare extensions the compiler must support

### DIFF
--- a/regex.cabal
+++ b/regex.cabal
@@ -53,7 +53,7 @@ Extra-Source-Files:
     src/Text/RE/TDFA/Text/Lazy.hs
 
 
-Cabal-Version:          >= 1.16
+Cabal-Version:          >= 1.10
 
 Source-Repository head
     type:               git
@@ -103,6 +103,26 @@ Library
       Text.RE.Tools.Sed
 
     Default-Language:   Haskell2010
+    Other-extensions:
+      AllowAmbiguousTypes
+      CPP
+      DeriveDataTypeable
+      DeriveGeneric
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      OverloadedStrings
+      QuasiQuotes
+      RecordWildCards
+      ScopedTypeVariables
+      TemplateHaskell
+      TypeSynonymInstances
+      UndecidableInstances      
+    
     GHC-Options:
       -Wall
       -fwarn-tabs


### PR DESCRIPTION
This makes the cabal solver aware that `regex` needs a compiler which supports Haskell2010 + the stated language extension. For one, this avoids cabal running into compile errors with older GHCs or those GHCs which don't support TemplateHaskell, but more importantly it gives the solver the chance to find alternative install-plans which don't require those extensions as well as give better error messages; also tooling like the matrix hackage builder relies on this meta-data, and if, at some point in the future, cabal learns to solve for compilers, this will also be valuable meta-data...

See also http://cabal.readthedocs.io/en/latest/developing-packages.html#pkg-field-other-extensions