### PR TITLE
Add max versions for base and base-compat

### DIFF
--- a/lib/cabal-masters/constraints-incl.cabal
+++ b/lib/cabal-masters/constraints-incl.cabal
@@ -1,6 +1,6 @@
 %-    array                   >= 0.4
-%-    base                    >= 4        && <  5
-%-    base-compat             >= 0.6
+%-    base                    >= 4        && <  4.13
+%-    base-compat             >= 0.6      && <  0.11
 %-    blaze-html              >= 0.8.1.0
 %-    bytestring              == 0.10.*
 %-    containers              >= 0.4

--- a/lib/mega-regex.cabal
+++ b/lib/mega-regex.cabal
@@ -176,8 +176,8 @@ Library
 
     Build-depends:
         array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , hashable             == 1.2.*
@@ -213,8 +213,8 @@ Executable re-gen-cabals
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -243,8 +243,8 @@ Test-Suite re-gen-cabals-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -273,8 +273,8 @@ Executable re-gen-modules
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -302,8 +302,8 @@ Test-Suite re-gen-modules-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -330,8 +330,8 @@ Executable re-include
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -356,8 +356,8 @@ Test-Suite re-include-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -383,8 +383,8 @@ Executable re-nginx-log-processor
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -417,8 +417,8 @@ Test-Suite re-nginx-log-processor-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -450,8 +450,8 @@ Executable re-prep
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -479,8 +479,8 @@ Test-Suite re-prep-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -508,8 +508,8 @@ Executable re-sort-imports
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -535,8 +535,8 @@ Test-Suite re-sort-imports-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -563,8 +563,8 @@ Executable re-tests
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -604,8 +604,8 @@ Test-Suite re-tests-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -644,8 +644,8 @@ Executable re-top
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -677,8 +677,8 @@ Test-Suite re-top-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -712,8 +712,8 @@ Executable re-tutorial
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -756,8 +756,8 @@ Test-Suite re-tutorial-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -802,8 +802,8 @@ Test-Suite re-tutorial-os-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -846,8 +846,8 @@ Executable re-tutorial-options
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -890,8 +890,8 @@ Test-Suite re-tutorial-options-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -934,8 +934,8 @@ Executable re-tutorial-replacing
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -978,8 +978,8 @@ Test-Suite re-tutorial-replacing-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1022,8 +1022,8 @@ Executable re-tutorial-testbench
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1066,8 +1066,8 @@ Test-Suite re-tutorial-testbench-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1110,8 +1110,8 @@ Executable re-tutorial-tools
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1155,8 +1155,8 @@ Test-Suite re-tutorial-tools-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0

--- a/lib/regex-examples.cabal
+++ b/lib/regex-examples.cabal
@@ -89,8 +89,8 @@ Executable re-gen-cabals
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -119,8 +119,8 @@ Test-Suite re-gen-cabals-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -149,8 +149,8 @@ Executable re-gen-modules
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -178,8 +178,8 @@ Test-Suite re-gen-modules-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -206,8 +206,8 @@ Executable re-include
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -232,8 +232,8 @@ Test-Suite re-include-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -260,8 +260,8 @@ Executable re-nginx-log-processor
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -295,8 +295,8 @@ Test-Suite re-nginx-log-processor-test
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -328,8 +328,8 @@ Executable re-prep
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -357,8 +357,8 @@ Test-Suite re-prep-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -386,8 +386,8 @@ Executable re-sort-imports
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -413,8 +413,8 @@ Test-Suite re-sort-imports-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -442,8 +442,8 @@ Executable re-tests
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -484,8 +484,8 @@ Test-Suite re-tests-test
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -524,8 +524,8 @@ Executable re-top
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -557,8 +557,8 @@ Test-Suite re-top-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -592,8 +592,8 @@ Executable re-tutorial
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -636,8 +636,8 @@ Test-Suite re-tutorial-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -682,8 +682,8 @@ Test-Suite re-tutorial-os-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -727,8 +727,8 @@ Executable re-tutorial-options
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -772,8 +772,8 @@ Test-Suite re-tutorial-options-test
         regex                
       , regex-with-pcre      
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -816,8 +816,8 @@ Executable re-tutorial-replacing
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -860,8 +860,8 @@ Test-Suite re-tutorial-replacing-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -904,8 +904,8 @@ Executable re-tutorial-testbench
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -948,8 +948,8 @@ Test-Suite re-tutorial-testbench-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -992,8 +992,8 @@ Executable re-tutorial-tools
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1037,8 +1037,8 @@ Test-Suite re-tutorial-tools-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0

--- a/lib/regex-with-pcre.cabal
+++ b/lib/regex-with-pcre.cabal
@@ -95,8 +95,8 @@ Library
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , regex-base           == 0.93.*

--- a/lib/regex.cabal
+++ b/lib/regex.cabal
@@ -124,8 +124,8 @@ Library
 
     Build-depends:
         array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , hashable             == 1.2.*

--- a/regex.cabal
+++ b/regex.cabal
@@ -176,8 +176,8 @@ Library
 
     Build-depends:
         array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , hashable             == 1.2.*
@@ -213,8 +213,8 @@ Executable re-gen-cabals
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -243,8 +243,8 @@ Test-Suite re-gen-cabals-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -273,8 +273,8 @@ Executable re-gen-modules
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -302,8 +302,8 @@ Test-Suite re-gen-modules-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , regex-base           == 0.93.*
@@ -330,8 +330,8 @@ Executable re-include
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -356,8 +356,8 @@ Test-Suite re-include-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , shelly               >= 1.6.1.2
@@ -383,8 +383,8 @@ Executable re-nginx-log-processor
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -417,8 +417,8 @@ Test-Suite re-nginx-log-processor-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -450,8 +450,8 @@ Executable re-prep
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -479,8 +479,8 @@ Test-Suite re-prep-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -508,8 +508,8 @@ Executable re-sort-imports
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -535,8 +535,8 @@ Test-Suite re-sort-imports-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , directory            >= 1.2.1.0
       , filepath             >= 1.3.0.2
@@ -563,8 +563,8 @@ Executable re-tests
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -604,8 +604,8 @@ Test-Suite re-tests-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -644,8 +644,8 @@ Executable re-top
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -677,8 +677,8 @@ Test-Suite re-top-test
 
     Build-depends:
         regex                
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , blaze-html           >= 0.8.1.0
       , bytestring           == 0.10.*
       , data-default         >= 0.5.3
@@ -712,8 +712,8 @@ Executable re-tutorial
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -756,8 +756,8 @@ Test-Suite re-tutorial-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -802,8 +802,8 @@ Test-Suite re-tutorial-os-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -846,8 +846,8 @@ Executable re-tutorial-options
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -890,8 +890,8 @@ Test-Suite re-tutorial-options-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -934,8 +934,8 @@ Executable re-tutorial-replacing
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -978,8 +978,8 @@ Test-Suite re-tutorial-replacing-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1022,8 +1022,8 @@ Executable re-tutorial-testbench
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1066,8 +1066,8 @@ Test-Suite re-tutorial-testbench-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1110,8 +1110,8 @@ Executable re-tutorial-tools
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0
@@ -1155,8 +1155,8 @@ Test-Suite re-tutorial-tools-test
     Build-depends:
         regex                
       , array                >= 0.4
-      , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base                 >= 4        && <  4.13
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , directory            >= 1.2.1.0


### PR DESCRIPTION
The MonadFail proposal is forced in base 4.13 and base-compat 0.11, and we don't support it yet.

This fixes errors when trying to install with cabal (because it pulls base-compat 0.11 otherwise) that look something like this:
```
Text/RE/ZeInternals/SearchReplace.hs:47:55: error:
    • Could not deduce (MonadFail m) arising from a use of ‘fail’
      from the context: Monad m
...
   |
47 | compileSearchReplace_ pack compile_re sr_tpl = either fail return $ do
   |                                                       ^^^^
```