### PR TITLE
Preventing unmatched case from being considered utf8 decoding error.

### DIFF
--- a/Text/RE/ZeInternals/Types/Match.lhs
+++ b/Text/RE/ZeInternals/Types/Match.lhs
@@ -246,7 +246,10 @@ utf8_correct_bs bs ix0 ln0 = case ix0+ln0 > BW.length bs of
     False -> skip 0 0     -- BW.index calls below should not fail
   where
     skip ix di = case compare ix ix0 of
-      GT -> error "utf8_correct_bs: UTF-8 decoding error"
+      GT -> case ix0 of
+        -- -1 is used as a magic number to indicate failure to match
+        -1 -> CharRange ix0 ln0
+        _ -> error "utf8_correct_bs: UTF-8 decoding error"
       EQ -> count ix di 0 ln0
       LT -> case u8_width $ BW.index bs ix of
         Single    -> skip (ix+1)   di


### PR DESCRIPTION
We were hitting similar problems as described [here](https://github.com/iconnect/regex/issues/171), after some exploration, it seems like the issue is that the library uses an array index of `-1` to indicated a failure to match, and at the same time, uses those indices to convert byte offset+index to character offset+index in an utf8 encoded byte string. 

From my understanding of the code, this will fail when we use the `-1` magic index.

On the other hand my understanding of the whole code/library is quite rudimentary, and this was only done in an afternoon of investigation. This change did however fix the error we had on our end, and regexes started working as expected (so far).

### Why a draft?

This was all very preliminary work, and given my unfamiliarity with the code base, I'm unsure whether this is a proper fix, of if I'm breaking something else.